### PR TITLE
fix single quote string grammar

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -12,7 +12,7 @@
         { "open": "{", "close": "}" },
         { "open": "[", "close": "]" },
         { "open": "(", "close": ")" },
-        { "open": "'", "close": "'", "notIn": ["string", "comment"] },
+        { "open": "'", "close": "", "notIn": ["string", "comment"] },
         { "open": "\"", "close": "\"", "notIn": ["string"] },
         { "open": "`", "close": "`", "notIn": ["string", "comment"] },
         { "open": "/**", "close": " */", "notIn": ["string"] }
@@ -22,7 +22,7 @@
         ["{", "}"],
         ["[", "]"],
         ["(", ")"],
-        ["'", "'"],
+        ["'", " "],
         ["\"", "\""],
         ["`", "`"]
       ],

--- a/syntaxes/pact.tmLanguage.json
+++ b/syntaxes/pact.tmLanguage.json
@@ -310,7 +310,7 @@
 		"patterns": [
 		  {
 			"begin": "'",
-			"end": "(?=\\s|[,:\"'.])",
+			"end": "(?=\\s|[],:\"'.)])",
 			"name": "string.quoted.symbol.pact"
 		  }
 		]


### PR DESCRIPTION
- close the string if it's followed by ) otherwise it looks like the ) is part of the string. eg 'blad)
- closing the single quote string on closing square bracket
- don't automatically add additional closing quote on typing a single quote