### PR TITLE
feat(coverage): display code coverage in vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.code-workspace
+node_modules
+out
+.vscode/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Pact executable and pact-lsp paths can be set from the settings menu.
 
 ## Release Notes
 
+### 0.0.6
+
+Added Code Coverage
+Added new logo
+
 ### 0.0.5
 
 Added Pact LSP client

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
                 "vscode-languageclient": "^8.1.0"
             },
             "devDependencies": {
+                "@lcov-viewer/cli": "^1.3.0",
                 "@types/glob": "^8.0.1",
                 "@types/mocha": "^10.0.1",
                 "@types/node": "16.x",
@@ -124,6 +125,18 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
             "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
             "dev": true
+        },
+        "node_modules/@lcov-viewer/cli": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@lcov-viewer/cli/-/cli-1.3.0.tgz",
+            "integrity": "sha512-A9altXh2ZyeuagYZsJqVja6WMlgGJGcV+SHOOgIZB+CA2bfk78vgOqrPJrWg+IflFpoEzo1QeqwH4WbKSM4d9A==",
+            "dev": true,
+            "dependencies": {
+                "commander": "^9.3.0"
+            },
+            "bin": {
+                "lcov-viewer": "lib/index.js"
+            }
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -680,6 +693,15 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
+        },
+        "node_modules/commander": {
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+            "dev": true,
+            "engines": {
+                "node": "^12.20.0 || >=14"
+            }
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -2470,6 +2492,15 @@
             "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
             "dev": true
         },
+        "@lcov-viewer/cli": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@lcov-viewer/cli/-/cli-1.3.0.tgz",
+            "integrity": "sha512-A9altXh2ZyeuagYZsJqVja6WMlgGJGcV+SHOOgIZB+CA2bfk78vgOqrPJrWg+IflFpoEzo1QeqwH4WbKSM4d9A==",
+            "dev": true,
+            "requires": {
+                "commander": "^9.3.0"
+            }
+        },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2851,6 +2882,12 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "commander": {
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
             "dev": true
         },
         "concat-map": {

--- a/package.json
+++ b/package.json
@@ -77,13 +77,15 @@
         "watch": "tsc -watch -p ./",
         "pretest": "npm run compile && npm run lint",
         "lint": "eslint src --ext ts",
-        "test": "node ./out/test/runTest.js"
+        "test": "node ./out/test/runTest.js",
+        "coverage:html": "lcov-viewer lcov"
     },
     "devDependencies": {
-        "@types/vscode": "^1.75.0",
+        "@lcov-viewer/cli": "^1.3.0",
         "@types/glob": "^8.0.1",
         "@types/mocha": "^10.0.1",
         "@types/node": "16.x",
+        "@types/vscode": "^1.75.0",
         "@typescript-eslint/eslint-plugin": "^5.49.0",
         "@typescript-eslint/parser": "^5.49.0",
         "@vscode/test-electron": "^2.2.2",
@@ -98,5 +100,9 @@
     },
     "dependencies": {
         "vscode-languageclient": "^8.1.0"
-    }
+    },
+    "extensionDependencies": [
+        "ryanluker.vscode-coverage-gutters",
+        "george-alisson.html-preview-vscode"
+    ]
 }


### PR DESCRIPTION
This PR enables code coverage reporting for .pact and .repl files in visual studio code. Covered and uncovered lines will be highlighted in the editor with green and red, respectively. An HTML report will also be generated in a `coverage/html` folder relative to the file that was execute. It can be opened in preview mode by right-clicking `coverage/html/index.html` and selecting "Open preview" in the context menu.

https://github.com/kadena-community/pact-vscode/assets/2759225/e6d84401-350a-4f66-9bf9-babc7ab5f0d3

