### PR TITLE
Revert "Fix symbol regex and format json file"

### DIFF
--- a/syntaxes/pact.tmLanguage.json
+++ b/syntaxes/pact.tmLanguage.json
@@ -1,347 +1,350 @@
 {
-  "scopeName": "source.pact",
-  "fileTypes": ["pact", "repl"],
-  "foldingStartMarker": "\\(\\s*$",
-  "foldingStopMarker": "^\\s*\\)",
-  "name": "Pact",
-  "patterns": [
-    {
-      "include": "#comment"
-    },
-    {
-      "include": "#sexp"
-    },
-    {
-      "include": "#reserved"
-    },
-    {
-      "include": "#type"
-    },
-    {
-      "include": "#string"
-    },
-    {
-      "include": "#list"
-    },
-    {
-      "include": "#object"
-    },
-    {
-      "include": "#literal"
-    },
-    {
-      "include": "#symbol"
-    },
-    {
-      "include": "#metas"
-    },
-    {
-      "include": "#let"
-    }
-  ],
-  "repository": {
-    "comment": {
-      "captures": {
-        "1": {
-          "name": "punctuation.definition.comment.pact"
-        }
-      },
-      "match": "(;).*$\\n?",
-      "name": "comment.line.semicolon.pact"
-    },
-    "literal": {
-      "patterns": [
-        {
-          "match": "(true|false)",
-          "name": "constant.language.boolean.pact"
-        },
-        {
-          "match": "\\b(-?\\d+\\.\\d+)\\b",
-          "name": "constant.numeric.double.pact"
-        },
-        {
-          "match": "\\b(-?\\d+)\\b",
-          "name": "constant.numeric.integer.pact"
-        },
-        {
-          "match": "(:=?)",
-          "name": "constant.language.binder.pact"
-        }
-      ]
-    },
-    "reserved": {
-      "patterns": [
-        {
-          "match": "\\b(module|interface|list|let|let\\*|defun|defpact|defconst|defschema|deftable|defcap|step|use|step-with-rollback|invariants?|properties|property|defproperty|bless|implements)\\b",
-          "name": "keyword.reserved.pact"
-        }
-      ]
-    },
-    "type": {
-      "patterns": [
-        {
-          "match": "(?:[:])(integer|decimal|time|bool|string|list|value|keyset|guard|(object|table)?\\{[\\w%#+\\-\\._&\\$@<>=\\?\\*!\\|/]+\\}|object|table)",
-          "captures": {
-            "1": {
-              "name": "keyword.reserved.type.pact"
-            }
-          }
-        }
-      ]
-    },
-    "object": {
-      "begin": "(\\{)",
-      "beginCaptures": {
-        "1": {
-          "name": "punctuation.section.object.begin.pact"
-        }
-      },
-      "end": "(\\}(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\})",
-      "endCaptures": {
-        "1": {
-          "name": "punctuation.section.object.end.trailing.pact"
-        },
-        "2": {
-          "name": "punctuation.section.object.end.pact"
-        }
-      },
-      "name": "meta.object.pact",
-      "patterns": [
-        {
-          "begin": "(:=)",
-          "beginCaptures": {
-            "1": {
-              "name": "constant.binder.pact"
-            }
-          },
-          "end": "([\\w%#+\\-_&\\$@<>=\\?\\*!\\|/]+)",
-          "endCaptures": {
-            "1": {
-              "name": "variable.binder.pact"
-            }
-          }
-        },
-        {
-          "include": "$self"
-        }
-      ]
-    },
-    "let": {
-      "begin": "\\((let\\*?)\\s",
-      "beginCaptures": {
-        "1": {
-          "name": "keyword.let.pact"
-        }
-      },
-      "end": "\\)",
-      "name": "meta.let.declaration.pact",
-      "patterns": [
-        {
-          "begin": "\\(",
-          "end": "(?=\\))",
-          "name": "meta.let.bindings.pact",
-          "patterns": [
-            {
-              "begin": "\\(([\\w%#+\\-_&\\$@<>=\\?\\*!\\|/]+)\\b",
-              "beginCaptures": {
-                "1": {
-                  "name": "variable.let.pact"
-                }
-              },
-              "end": "\\)",
-              "name": "meta.let.binding.pact",
-              "patterns": [
-                {
-                  "include": "$self"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    "sexp": {
-      "begin": "(\\()",
-      "beginCaptures": {
-        "1": {
-          "name": "punctuation.section.expression.begin.pact"
-        }
-      },
-      "end": "(\\))(\\n)|(\\)(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\))",
-      "endCaptures": {
-        "1": {
-          "name": "punctuation.section.expression.end.trailing.pact"
-        },
-        "2": {
-          "name": "meta.after-expression.pact"
-        },
-        "3": {
-          "name": "punctuation.section.expression.end.trailing.pact"
-        },
-        "4": {
-          "name": "punctuation.section.expression.end.pact"
-        }
-      },
-      "name": "meta.expression.pact",
-      "patterns": [
-        {
-          "include": "#deflam"
-        },
-        {
-          "include": "#defsimple"
-        },
-        {
-          "include": "#string"
-        },
-        {
-          "include": "#reserved"
-        },
-        {
-          "include": "#literal"
-        },
-        {
-          "include": "#list"
-        },
-        {
-          "include": "#object"
-        },
-        {
-          "include": "#let"
-        },
-        {
-          "include": "#sexp"
-        },
-        {
-          "match": "(?<=\\()(.+?)(?=\\s|\\))",
-          "captures": {
-            "1": {
-              "name": "entity.name.function.pact"
-            }
-          },
-          "patterns": [
-            {
-              "include": "$self"
-            }
-          ]
-        },
-        {
-          "include": "$self"
-        }
-      ]
-    },
-    "deflam": {
-      "begin": "(?<=\\()(defun|defpact|defcap)\\s+([\\w%#+\\-_&\\$@<>=\\?\\*!\\|/]+)",
-      "beginCaptures": {
-        "1": {
-          "name": "keyword.reserved.pact"
-        },
-        "2": {
-          "name": "entity.function.name.pact"
-        }
-      },
-      "name": "meta.definition.global.pact",
-      "end": "\\)",
-      "patterns": [
-        {
-          "include": "#arglist"
-        },
-        {
-          "include": "#type"
-        }
-      ]
-    },
-    "arglist": {
-      "begin": "(?<=\\()",
-      "end": "(?=\\))",
-      "patterns": [
-        {
-          "match": "([\\w%#+\\-_&\\$@<>=\\?\\*!\\|/]+)",
-          "name": "variable.name.arg.pact"
-        },
-        {
-          "include": "#type"
-        }
-      ]
-    },
-    "defsimple": {
-      "begin": "(?<=\\()(defconst|defschema|deftable|module|interface)\\s+([\\w%#+-_&\\$@<>=\\?\\*!\\|/]+)\\b",
-      "beginCaptures": {
-        "1": {
-          "name": "keyword.reserved.pact"
-        },
-        "2": {
-          "name": "entity.function.name.pact"
-        }
-      },
-      "end": "(?=\\))",
-      "name": "meta.definition.global.pact",
-      "patterns": [
-        {
-          "include": "$self"
-        }
-      ]
-    },
-    "string": {
-      "begin": "(?<!\\\\)(\")",
-      "beginCaptures": {
-        "1": {
-          "name": "punctuation.definition.string.begin.pact"
-        }
-      },
-      "end": "(?<!\\\\)(\")",
-      "endCaptures": {
-        "1": {
-          "name": "punctuation.definition.string.end.pact"
-        }
-      },
-      "name": "string.quoted.double.pact"
-    },
-    "atom": {
-      "patterns": [
-        {
-          "match": "([\\w%#+-_&\\$@<>=\\?\\*!\\|/]+)"
-        }
-      ]
-    },
-    "symbol": {
-      "patterns": [
-        {
-          "begin": "'",
-          "end": "(?=[\\s)|\\[\\],:\"'.])",
-          "name": "string.quoted.symbol.pact"
-        }
-      ]
-    },
-    "metas": {
-      "patterns": [
-        {
-          "match": "@\\w+",
-          "name": "variable.language.metas.pact"
-        }
-      ]
-    },
-    "list": {
-      "begin": "(\\[)",
-      "beginCaptures": {
-        "1": {
-          "name": "punctuation.section.list.begin.pact"
-        }
-      },
-      "end": "(\\](?=[\\}\\]\\)\\s]*(?:;|$)))|(\\])",
-      "endCaptures": {
-        "1": {
-          "name": "punctuation.section.list.end.trailing.pact"
-        },
-        "2": {
-          "name": "punctuation.section.list.end.pact"
-        }
-      },
-      "name": "meta.list.pact",
-      "patterns": [
-        {
-          "include": "$self"
-        }
-      ]
-    }
+	"scopeName": "source.pact",
+	"fileTypes": [
+	  "pact",
+	  "repl"
+	],
+	"foldingStartMarker": "\\(\\s*$",
+	"foldingStopMarker": "^\\s*\\)",
+	"name": "Pact",
+	"patterns": [
+	  {
+		"include": "#comment"
+	  },
+	  {
+		"include": "#sexp"
+	  },
+	  {
+		"include": "#reserved"
+	  },
+	  {
+		"include": "#type"
+	  },
+	  {
+		"include": "#string"
+	  },
+	  {
+		"include": "#list"
+	  },
+	  {
+		"include": "#object"
+	  },
+	  {
+		"include": "#literal"
+	  },
+	  {
+		"include": "#symbol"
+	  },
+	  {
+		"include": "#metas"
+	  },
+	  {
+		"include": "#let"
+	  }
+	],
+	"repository": {
+	  "comment": {
+		"captures": {
+		  "1": {
+			"name": "punctuation.definition.comment.pact"
+		  }
+		},
+		"match": "(;).*$\\n?",
+		"name": "comment.line.semicolon.pact"
+	  },
+	  "literal": {
+		"patterns": [
+		  {
+			"match": "(true|false)",
+			"name": "constant.language.boolean.pact"
+		  },
+		  {
+			"match": "\\b(-?\\d+\\.\\d+)\\b",
+			"name": "constant.numeric.double.pact"
+		  },
+		  {
+			"match": "\\b(-?\\d+)\\b",
+			"name": "constant.numeric.integer.pact"
+		  },
+		  {
+			"match": "(:=?)",
+			"name": "constant.language.binder.pact"
+		  }
+		]
+	  },
+	  "reserved": {
+		"patterns": [
+		  {
+			"match": "\\b(module|interface|list|let|let\\*|defun|defpact|defconst|defschema|deftable|defcap|step|use|step-with-rollback|invariants?|properties|property|defproperty|bless|implements)\\b",
+			"name": "keyword.reserved.pact"
+		  }
+		]
+	  },
+	  "type": {
+		"patterns": [
+		  {
+			"match": "(?:[:])(integer|decimal|time|bool|string|list|value|keyset|guard|(object|table)?\\{[\\w%#+\\-\\._&\\$@<>=\\?\\*!\\|/]+\\}|object|table)",
+			"captures": {
+			  "1": {
+				"name": "keyword.reserved.type.pact"
+			  }
+			}
+		  }
+		]
+	  },
+	  "object": {
+		"begin": "(\\{)",
+		"beginCaptures": {
+		  "1": {
+			"name": "punctuation.section.object.begin.pact"
+		  }
+		},
+		"end": "(\\}(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\})",
+		"endCaptures": {
+		  "1": {
+			"name": "punctuation.section.object.end.trailing.pact"
+		  },
+		  "2": {
+			"name": "punctuation.section.object.end.pact"
+		  }
+		},
+		"name": "meta.object.pact",
+		"patterns": [
+		  {
+			"begin": "(:=)",
+			"beginCaptures": {
+			  "1": {
+				"name": "constant.binder.pact"
+			  }
+			},
+			"end": "([\\w%#+\\-_&\\$@<>=\\?\\*!\\|/]+)",
+			"endCaptures": {
+			  "1": {
+				"name": "variable.binder.pact"
+			  }
+			}
+		  },
+		  {
+			"include": "$self"
+		  }
+		]
+	  },
+	  "let": {
+		"begin": "\\((let\\*?)\\s",
+		"beginCaptures": {
+		  "1": {
+			"name": "keyword.let.pact"
+		  }
+		},
+		"end": "\\)",
+		"name": "meta.let.declaration.pact",
+		"patterns": [
+		  {
+			"begin": "\\(",
+			"end": "(?=\\))",
+			"name": "meta.let.bindings.pact",
+			"patterns": [
+			  {
+				"begin": "\\(([\\w%#+\\-_&\\$@<>=\\?\\*!\\|/]+)\\b",
+				"beginCaptures": {
+				  "1": {
+					"name": "variable.let.pact"
+				  }
+				},
+				"end": "\\)",
+				"name": "meta.let.binding.pact",
+				"patterns": [
+				  {
+					"include": "$self"
+				  }
+				]
+			  }
+			]
+		  }
+		]
+	  },
+	  "sexp": {
+		"begin": "(\\()",
+		"beginCaptures": {
+		  "1": {
+			"name": "punctuation.section.expression.begin.pact"
+		  }
+		},
+		"end": "(\\))(\\n)|(\\)(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\))",
+		"endCaptures": {
+		  "1": {
+			"name": "punctuation.section.expression.end.trailing.pact"
+		  },
+		  "2": {
+			"name": "meta.after-expression.pact"
+		  },
+		  "3": {
+			"name": "punctuation.section.expression.end.trailing.pact"
+		  },
+		  "4": {
+			"name": "punctuation.section.expression.end.pact"
+		  }
+		},
+		"name": "meta.expression.pact",
+		"patterns": [
+		  {
+			"include": "#deflam"
+		  },
+		  {
+			"include": "#defsimple"
+		  },
+		  {
+			"include": "#string"
+		  },
+		  {
+			"include": "#reserved"
+		  },
+		  {
+			"include": "#literal"
+		  },
+		  {
+			"include": "#list"
+		  },
+		  {
+			"include": "#object"
+		  },
+		  {
+			"include": "#let"
+		  },
+		  {
+			"include": "#sexp"
+		  },
+		  {
+			"match": "(?<=\\()(.+?)(?=\\s|\\))",
+			"captures": {
+			  "1": {
+				"name": "entity.name.function.pact"
+			  }
+			},
+			"patterns": [
+			  {
+				"include": "$self"
+			  }
+			]
+		  },
+		  {
+			"include": "$self"
+		  }
+		]
+	  },
+	  "deflam": {
+		"begin": "(?<=\\()(defun|defpact|defcap)\\s+([\\w%#+\\-_&\\$@<>=\\?\\*!\\|/]+)",
+		"beginCaptures": {
+		  "1": {
+			"name": "keyword.reserved.pact"
+		  },
+		  "2": {
+			"name": "entity.function.name.pact"
+		  }
+		},
+		"name": "meta.definition.global.pact",
+		"end": "\\)",
+		"patterns": [
+		  {
+			"include": "#arglist"
+		  },
+		  {
+			"include": "#type"
+		  }
+		]
+	  },
+	  "arglist": {
+		"begin": "(?<=\\()",
+		"end": "(?=\\))",
+		"patterns": [
+		  {
+			"match": "([\\w%#+\\-_&\\$@<>=\\?\\*!\\|/]+)",
+			"name": "variable.name.arg.pact"
+		  },
+		  {
+			"include": "#type"
+		  }
+		]
+	  },
+	  "defsimple": {
+		"begin": "(?<=\\()(defconst|defschema|deftable|module|interface)\\s+([\\w%#+-_&\\$@<>=\\?\\*!\\|/]+)\\b",
+		"beginCaptures": {
+		  "1": {
+			"name": "keyword.reserved.pact"
+		  },
+		  "2": {
+			"name": "entity.function.name.pact"
+		  }
+		},
+		"end": "(?=\\))",
+		"name": "meta.definition.global.pact",
+		"patterns": [
+		  {
+			"include": "$self"
+		  }
+		]
+	  },
+	  "string": {
+		"begin": "(?<!\\\\)(\")",
+		"beginCaptures": {
+		  "1": {
+			"name": "punctuation.definition.string.begin.pact"
+		  }
+		},
+		"end": "(?<!\\\\)(\")",
+		"endCaptures": {
+		  "1": {
+			"name": "punctuation.definition.string.end.pact"
+		  }
+		},
+		"name": "string.quoted.double.pact"
+	  },
+	  "atom": {
+		"patterns": [
+		  {
+			"match": "([\\w%#+-_&\\$@<>=\\?\\*!\\|/]+)"
+		  }
+		]
+	  },
+	  "symbol": {
+		"patterns": [
+		  {
+			"begin": "'",
+			"end": "(?=\\s|[],:\"'.)])",
+			"name": "string.quoted.symbol.pact"
+		  }
+		]
+	  },
+	  "metas": {
+		"patterns": [
+		  {
+			"match": "@\\w+",
+			"name": "variable.language.metas.pact"
+		  }
+		]
+	  },
+	  "list": {
+		"begin": "(\\[)",
+		"beginCaptures": {
+		  "1": {
+			"name": "punctuation.section.list.begin.pact"
+		  }
+		},
+		"end": "(\\](?=[\\}\\]\\)\\s]*(?:;|$)))|(\\])",
+		"endCaptures": {
+		  "1": {
+			"name": "punctuation.section.list.end.trailing.pact"
+		  },
+		  "2": {
+			"name": "punctuation.section.list.end.pact"
+		  }
+		},
+		"name": "meta.list.pact",
+		"patterns": [
+		  {
+			"include": "$self"
+		  }
+		]
+	  }
+	}
   }
-}


### PR DESCRIPTION
Reverts kadena-community/pact-vscode#10

The change is just not needed, it lowers the readability of the regex changed and the way it was applied -mixing formatting with attempts at fixing something- is bad practice with regard to change management. If there is a "distinct behavior", which I couldn't identify so far, it should be possible to describe it.